### PR TITLE
Leaflet 1.0 no longer uses 'clickable' in options. #8

### DIFF
--- a/L.SimpleGraticule.js
+++ b/L.SimpleGraticule.js
@@ -18,7 +18,7 @@ L.SimpleGraticule = L.LayerGroup.extend({
         opacity: 0.6,
         weight: 1,
         interactive: false,
-        clickable: false//legacy support
+        clickable: false //legacy support
     },
 
     initialize: function(options) {
@@ -141,7 +141,7 @@ L.SimpleGraticule = L.LayerGroup.extend({
 
         return L.marker(latLng, {
             interactive: false,
-            clickable: false,//legacy support
+            clickable: false, //legacy support
             icon: L.divIcon({
                 iconSize: [0, 0],
                 className: 'leaflet-grid-label',
@@ -153,7 +153,7 @@ L.SimpleGraticule = L.LayerGroup.extend({
     addOriginLabel: function() {
         return L.marker([0, 0], {
             interactive: false,
-            clickable: false,//legacy support
+            clickable: false, //legacy support
             icon: L.divIcon({
                 iconSize: [0, 0],
                 className: 'leaflet-grid-label',

--- a/L.SimpleGraticule.js
+++ b/L.SimpleGraticule.js
@@ -17,7 +17,8 @@ L.SimpleGraticule = L.LayerGroup.extend({
         color: '#111',
         opacity: 0.6,
         weight: 1,
-        clickable: false
+        interactive: false,
+        clickable: false//legacy support
     },
 
     initialize: function(options) {

--- a/L.SimpleGraticule.js
+++ b/L.SimpleGraticule.js
@@ -140,7 +140,8 @@ L.SimpleGraticule = L.LayerGroup.extend({
         }
 
         return L.marker(latLng, {
-            clickable: false,
+            interactive: false,
+            clickable: false,//legacy support
             icon: L.divIcon({
                 iconSize: [0, 0],
                 className: 'leaflet-grid-label',
@@ -151,7 +152,8 @@ L.SimpleGraticule = L.LayerGroup.extend({
 
     addOriginLabel: function() {
         return L.marker([0, 0], {
-            clickable: false,
+            interactive: false,
+            clickable: false,//legacy support
             icon: L.divIcon({
                 iconSize: [0, 0],
                 className: 'leaflet-grid-label',


### PR DESCRIPTION
It is tested with both Leaflet  0.7 and [the current 1.0-dev branch.](https://github.com/JrFolk/Leaflet/commit/7ebbd197373fed03348d18d5cfeb6dbb965b19b3)
#8
