### PR TITLE
[Fix] Correct context for redraw in L.SimpleGraticule

### DIFF
--- a/L.SimpleGraticule.js
+++ b/L.SimpleGraticule.js
@@ -36,7 +36,7 @@ L.SimpleGraticule = L.LayerGroup.extend({
     },
 
     onRemove: function(map) {
-        map.off('viewreset '+ this.options.redraw, this.map);
+        map.off('viewreset '+ this.options.redraw, this.redraw, this);
         this.eachLayer(this.removeLayer, this);
     },
 


### PR DESCRIPTION
This pull request includes a minor fix to the `L.SimpleGraticule` class in `L.SimpleGraticule.js`. The change ensures that the `onRemove` method correctly references the `redraw` function when removing the event listener.

* [`L.SimpleGraticule.js`](diffhunk://#diff-5fde60a4d2b68d841fc14f7eb63c791bd0db689b3b7406ffb86c5c894437a7aaL39-R39): Updated the `onRemove` method to pass the correct `redraw` function and `this` context when calling `map.off`.